### PR TITLE
Fix typo in concepts.json

### DIFF
--- a/streamside/resources/wisen/concepts.json
+++ b/streamside/resources/wisen/concepts.json
@@ -51000,13 +51000,13 @@
   },
   "wisen-unknown": {
     "description": "Predicate",
-    "aliases:: [
+    "aliases: [
     ],
     "type": "pred"
   },
   "wisen-question": {
     "description": "Predicate",
-    "aliases:: [
+    "aliases: [
     ],
     "type": "pred"
   },


### PR DESCRIPTION
Fixed typo in concepts.json under "wisen-unknown" and "wisen-question".